### PR TITLE
Cu 86c3mgwb8 debunking the myth of the recruitment interview

### DIFF
--- a/client/src/features/articles/ArticlePage.tsx
+++ b/client/src/features/articles/ArticlePage.tsx
@@ -60,6 +60,10 @@ const ArticlePage = () => {
                 import(`../../pages/ui-tests-playwright-maf${fileSuffix}.md?raw`)
                     .then((mod) => mod.default)
                     .catch(() => import(`../../pages/ui-tests-playwright-maf.md?raw`).then((mod) => mod.default)),
+            "playwright-assertions-when-you-need-await": () =>
+                import(`../../pages/playwright-assertions-when-you-need-await${fileSuffix}.md?raw`)
+                    .then((mod) => mod.default)
+                    .catch(() => import(`../../pages/playwright-assertions-when-you-need-await.md?raw`).then((mod) => mod.default)),
         };
     }, [fileSuffix]);
 

--- a/client/src/features/articles/data.ts
+++ b/client/src/features/articles/data.ts
@@ -89,7 +89,7 @@ export const articles: Article[] = [
       pl: "Testowanie komponentów React z Testing Library vs Playwright - co wybrać i kiedy?",
       en: "Testing React Components with Testing Library vs Playwright – Which One to Choose and When?",
     },
-   link: "/articles/react-testing-library-vs-playwright",
+    link: "/articles/react-testing-library-vs-playwright",
   },
   {
     title: {
@@ -151,5 +151,16 @@ export const articles: Article[] = [
     },
     link: "/articles/automatic-update-dates-is-project-portfolio",
   },
-
+  {
+    title: {
+      pl: "Asercje w Playwright: Kiedy faktycznie potrzebujesz await?",
+      en: "Assertions in Playwright: When Do You Actually Need await?",
+    },
+    date: "2025-05-20",
+    description: {
+      pl: "Analiza techniczna dotycząca używania słowa kluczowego await z asercjami w Playwright. Artykuł obala popularny mit, że wszystkie asercje wymagają await, prezentując szczegółową analizę różnych typów asercji oraz wskazówki, kiedy await jest niezbędne, a kiedy niepotrzebne.",
+      en: "Technical analysis of using the await keyword with assertions in Playwright. This article debunks the common myth that all assertions require await, presenting a detailed breakdown of different assertion types and clear guidelines on when await is necessary and when it's redundant.",
+    },
+    link: "/articles/playwright-assertions-when-you-need-await",
+  },
 ];

--- a/client/src/pages/playwright-assertions-when-you-need-await-en.md
+++ b/client/src/pages/playwright-assertions-when-you-need-await-en.md
@@ -1,0 +1,108 @@
+# Assertions in Playwright: When Do You Actually Need await?
+
+## Introduction
+
+In the world of automated testing for web applications, Playwright has become one of the most popular tools. However, even experienced QA engineers may have doubts about the correct use of assertions, especially when it comes to using the ***await*** keyword. I often hear the opinion that "every assertion in Playwright requires await, otherwise the test will be unstable." Is this really the case?
+
+In this article, I'll debunk this myth and explain when ***await*** is essential and when it's completely unnecessary—all backed by official documentation and code analysis.
+
+## Two Types of Assertions in Playwright
+
+Let's start with the key information: Playwright has two fundamentally different types of assertions:
+
+### 1. Auto-Retrying Assertions (requiring ***await***)
+
+These assertions are **asynchronous** and automatically retried. They will try to verify the condition multiple times until it is met or the timeout expires (default is 5 seconds). Examples:
+
+```typescript
+await expect(locator).toBeVisible();
+await expect(page).toHaveURL(expectedUrl);
+await expect(locator).toHaveText('Expected text');
+```
+
+The documentation clearly states that "retrying assertions are async, so you must await them."
+
+### 2. Non-Retrying Assertions (not requiring ***await***)
+
+These assertions work synchronously, verifying values that we already have in memory:
+
+```typescript
+expect(value).toBe(5);
+expect(array).toContain('element');
+expect(object).toHaveProperty('name');
+```
+
+These assertions **do not require ***await***** because they don't perform any asynchronous operations. They are just simple value comparisons.
+
+## Code Analysis and Step-by-Step Execution
+
+Let's look at an example test:
+
+```typescript
+test("When_userClicksButton_Then_correctPageOpens", async ({ page }) => {
+  // Arrange & Act
+  await page.goto('https://example.com');
+  await page.getByRole('button', { name: 'Click me' }).click();
+
+  // Assert
+  await expect(page).toHaveURL('https://example.com/destination');
+  const headingText = await page.locator('h1').textContent();
+  expect(headingText?.trim()).toBe('Welcome to Destination');
+});
+```
+
+Let's analyze the execution of this test step by step:
+
+1. The test opens the example.com page
+2. The test clicks the "Click me" button
+3. **Assertion 1**: The test checks the page URL using `await expect(page).toHaveURL(...)`
+   - This is an asynchronous assertion (auto-retrying)
+   - It will attempt to check the URL multiple times until it matches the expectation
+   - **Requires ***await*** for the test to wait for the condition to be met**
+4. The test retrieves the heading text using `await page.locator('h1').textContent()`
+   - This is an asynchronous operation because it requires communication with the browser
+   - **Requires ***await*** to wait for the text to be retrieved**
+5. **Assertion 2**: The test compares the retrieved text using `expect(headingText?.trim()).toBe(...)`
+   - This is a synchronous assertion (non-retrying)
+   - It operates on a value that has already been retrieved in step 4
+   - **Does not require ***await*** because there is no asynchronous operation here**
+
+## Why Omitting ***await*** in the Second expect is Correct?
+
+The crucial fact here is that in step 4 we've already asynchronously retrieved the header content. By the time we execute the assertion in step 5, the `headingText` value is already available in our test's memory. We're not performing any operation that would require communication with the browser.
+
+In this case, adding ***await*** before `expect(headingText?.trim()).toBe(...)` would not only be unnecessary but even misleading, as it would suggest that we're performing some asynchronous operation here, which is not true.
+
+## When Does Omitting ***await*** Actually Cause Problems?
+
+Test stability issues occur when we don't use ***await*** for auto-retrying assertions:
+
+```typescript
+// Bad - missing await for auto-retrying assertion
+expect(page).toHaveURL('https://example.com/destination'); // Error! Should be await
+```
+
+In the above case, the test won't wait for the URL to change and may continue execution even if the page hasn't loaded yet, leading to unstable tests.
+
+## What Does the Official Documentation Say?
+
+Playwright's documentation is very clear on this matter. In the "Auto-retrying assertions" section, it lists assertions that require ***await***, and in the "Non-retrying assertions" section, those that don't.
+
+Moreover, the documentation explicitly states:
+
+> "These assertions [non-retrying] allow to test any conditions, but do not auto-retry."
+
+This means that these assertions are designed precisely for testing conditions without auto-retrying, which is exactly what we need when comparing already retrieved values.
+
+## Conclusions
+
+The myth that "every assertion in Playwright must use await" is false and stems from a misunderstanding of the differences between assertion types. The correct approach is:
+
+1. Use ***await*** for auto-retrying assertions that communicate with the browser
+2. Don't use ***await*** for simple comparisons of values you already have in memory
+
+Following these principles will allow you to write more readable, efficient, and precise tests that accurately reflect your intentions. Remember that good test code should be readable and unambiguous—adding unnecessary ***await*** where it's not needed only obscures the actual intentions of the test.
+
+---
+
+*Article based on the official Playwright documentation available at playwright.dev*

--- a/client/src/pages/playwright-assertions-when-you-need-await.md
+++ b/client/src/pages/playwright-assertions-when-you-need-await.md
@@ -1,0 +1,108 @@
+# Asercje w Playwright: Kiedy faktycznie potrzebujesz await?
+
+## Wprowadzenie
+
+W świecie testów automatycznych dla aplikacji webowych, Playwright stał się jednym z najpopularniejszych narzędzi. Jednak nawet doświadczeni inżynierowie QA mogą mieć wątpliwości dotyczące prawidłowego używania asercji, zwłaszcza gdy chodzi o stosowanie słowa kluczowego ***await***. Często słyszę opinię, że "każda asercja w Playwright wymaga await, inaczej test będzie niestabilny". Czy rzeczywiście tak jest?
+
+W tym artykule obalę ten mit i wyjaśnię, kiedy ***await*** jest niezbędny, a kiedy kompletnie zbędny — wszystko poparte oficjalną dokumentacją i analizą kodu.
+
+## Dwa typy asercji w Playwright
+
+Zacznijmy od kluczowej informacji: Playwright posiada dwa fundamentalnie różne typy asercji:
+
+### 1. Asercje Auto-Retrying (wymagające ***await***)
+
+Te asercje są **asynchroniczne** i automatycznie ponawiane. Będą próbowały weryfikować warunek wielokrotnie, aż zostanie spełniony lub upłynie limit czasu (domyślnie 5 sekund). Przykłady:
+
+```typescript
+await expect(locator).toBeVisible();
+await expect(page).toHaveURL(expectedUrl);
+await expect(locator).toHaveText('Oczekiwany tekst');
+```
+
+Dokumentacja wyraźnie wskazuje, że "asercje z auto-retrying są asynchroniczne, więc musisz używać await" (tłum. własne: "Note that retrying assertions are async, so you must await them").
+
+### 2. Asercje Non-Retrying (nie wymagające ***await***)
+
+Te asercje działają synchronicznie, weryfikując wartości, które już mamy w pamięci:
+
+```typescript
+expect(value).toBe(5);
+expect(array).toContain('element');
+expect(object).toHaveProperty('name');
+```
+
+Te asercje **nie wymagają ***await*****, ponieważ nie wykonują żadnych operacji asynchronicznych. Są to zwykłe porównania wartości.
+
+## Analiza kodu i wykonanie krok po kroku
+
+Przyjrzyjmy się przykładowemu testowi:
+
+```typescript
+test("When_userClicksButton_Then_correctPageOpens", async ({ page }) => {
+  // Arrange & Act
+  await page.goto('https://example.com');
+  await page.getByRole('button', { name: 'Click me' }).click();
+
+  // Assert
+  await expect(page).toHaveURL('https://example.com/destination');
+  const headingText = await page.locator('h1').textContent();
+  expect(headingText?.trim()).toBe('Welcome to Destination');
+});
+```
+
+Przeanalizujmy wykonanie tego testu krok po kroku:
+
+1. Test otwiera stronę example.com
+2. Test klika przycisk "Click me"
+3. **Asercja 1**: Test sprawdza URL strony za pomocą `await expect(page).toHaveURL(...)` 
+   - Jest to asercja asynchroniczna (auto-retrying)
+   - Będzie próbowała sprawdzić URL wielokrotnie, aż będzie zgodny z oczekiwaniem
+   - **Wymaga ***await***, aby test zaczekał na spełnienie warunku**
+4. Test pobiera tekst nagłówka za pomocą `await page.locator('h1').textContent()`
+   - Jest to operacja asynchroniczna, ponieważ wymaga komunikacji z przeglądarką
+   - **Wymaga ***await***, aby zaczekać na pobranie tekstu**
+5. **Asercja 2**: Test porównuje pobrany tekst za pomocą `expect(headingText?.trim()).toBe(...)`
+   - Jest to asercja synchroniczna (non-retrying)
+   - Operuje na wartości, która już została pobrana w kroku 4
+   - **Nie wymaga ***await***, ponieważ nie ma tu żadnej operacji asynchronicznej**
+
+## Dlaczego brak ***await*** w drugim expect jest poprawny?
+
+Kluczowy jest tutaj fakt, że w kroku 4 już pobraliśmy zawartość nagłówka asynchronicznie. W momencie wykonania asercji w kroku 5, wartość `headingText` jest już dostępna w pamięci naszego testu. Nie wykonujemy żadnej operacji, która wymagałaby komunikacji z przeglądarką.
+
+W takim przypadku dodanie ***await*** przed `expect(headingText?.trim()).toBe(...)` byłoby nie tylko zbędne, ale wręcz wprowadzające w błąd, ponieważ sugerowałoby, że wykonujemy tu jakąś operację asynchroniczną, co nie jest prawdą.
+
+## Kiedy brak ***await*** faktycznie powoduje problemy?
+
+Problemy z stabilnością testów występują, gdy nie używamy ***await*** dla asercji auto-retrying:
+
+```typescript
+// Źle - brak await przy asercji auto-retrying
+expect(page).toHaveURL('https://example.com/destination'); // Błąd! Powinno być await
+```
+
+W powyższym przypadku test nie zaczeka na zmianę URL i może kontynuować wykonanie, nawet jeśli strona jeszcze się nie załadowała, co prowadzi do niestabilnych testów.
+
+## Co mówi oficjalna dokumentacja?
+
+Dokumentacja Playwright jest w tej kwestii bardzo jasna. W sekcji "Auto-retrying assertions" wymienia asercje, które wymagają ***await***, a w sekcji "Non-retrying assertions" te, które go nie wymagają.
+
+Co więcej, dokumentacja wyraźnie stwierdza:
+
+> "These assertions [non-retrying] allow to test any conditions, but do not auto-retry."
+
+Oznacza to, że asercje te są przeznaczone właśnie do testowania warunków bez auto-ponawiania, co jest dokładnie tym, czego potrzebujemy w przypadku porównywania już pobranych wartości.
+
+## Wnioski
+
+Mit, że "każda asercja w Playwright musi używać await" jest nieprawdziwy i wynika z niezrozumienia różnic między typami asercji. Prawidłowe podejście to:
+
+1. Używaj ***await*** dla asercji auto-retrying, które komunikują się z przeglądarką
+2. Nie używaj ***await*** dla prostych porównań wartości, które już masz w pamięci
+
+Stosowanie tych zasad pozwoli pisać bardziej czytelne, wydajne i precyzyjne testy, które dokładnie odzwierciedlają twoje intencje. Pamiętaj, że dobry kod testowy powinien być czytelny i jednoznaczny - dodawanie zbędnych ***await*** tam, gdzie nie są potrzebne, tylko zaciemnia faktyczne intencje testu.
+
+---
+
+*Artykuł oparty na oficjalnej dokumentacji Playwright dostępnej na stronie playwright.dev*


### PR DESCRIPTION
Technical analysis of using the await keyword with assertions in Playwright. This article debunks the common myth that all assertions require await, presenting a detailed breakdown of different assertion types and clear guidelines on when await is necessary and when it's redundant.